### PR TITLE
add cell renderer to react wrapper

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -13,7 +13,17 @@ const cols = _range(0, 100).map((_idx) => ({} as any));
 rows[0].header = true;
 rows[0].height = 50;
 
+const renderer = (row: number, col: number, data: { formatted: string }) => {
+  // if (col % 2) {
+  //   return <b>{data.formatted}</b>;
+  // }
+  if (col === 0) {
+    return <a>{data.formatted}</a>;
+  }
+  return data.formatted;
+};
+
 render(
-  <ReactGrid rows={rows} cols={cols} />,
+  <ReactGrid rows={rows} cols={cols} cellRenderer={renderer} />,
   document.getElementById('app')
 );

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -14,9 +14,9 @@ rows[0].header = true;
 rows[0].height = 50;
 
 const renderer = (row: number, col: number, data: { formatted: string }) => {
-  // if (col % 2) {
-  //   return <b>{data.formatted}</b>;
-  // }
+  if (col % 2) {
+    return <b>{data.formatted}</b>;
+  }
   if (col === 0) {
     return <a>{data.formatted}</a>;
   }

--- a/src/lib/components/__tests__/grid.test.tsx
+++ b/src/lib/components/__tests__/grid.test.tsx
@@ -32,6 +32,9 @@ const mockGridCreate = jest.fn((o: any) => ({
   build: mockGridBuild,
   rows: mockRowDim,
   cols: mockColDim,
+  colModel: {
+    createBuilder: jest.fn()
+  },
   dataModel: {
     setDirty: mockDataSetDirty
   }

--- a/src/lib/components/grid.tsx
+++ b/src/lib/components/grid.tsx
@@ -1,6 +1,7 @@
 // tslint:disable-next-line:no-unused-variable
 import * as React from 'react';
-import { Component } from 'react';
+import { Component, ReactElement } from 'react';
+import * as ReactDOM from 'react-dom';
 
 import {
   create,
@@ -9,6 +10,7 @@ import {
   IGridDataResult,
   IGridDimension,
   IGridOpts,
+  IRowColBuilder,
   IRowColDescriptor,
   IRowDescriptor
 } from 'grid';
@@ -17,12 +19,14 @@ export interface IGridProps extends IGridOpts {
   rows: Array<Partial<IRowDescriptor>>;
   cols: Array<Partial<IColDescriptor>>;
   data?: Array<Array<IGridDataResult<any>>>;
+  cellRenderer?(virtualRow: number, virtualCol: number, data: IGridDataResult<any>): ReactElement<any> | string;
 }
 
 export interface IGridState { }
 
 export class ReactGrid extends Component<IGridProps, IGridState> {
   grid: Grid;
+  cellRendererBuilder: IRowColBuilder | undefined;
   gridContainer: HTMLElement;
   reactContainer: HTMLElement | null;
 
@@ -46,16 +50,20 @@ export class ReactGrid extends Component<IGridProps, IGridState> {
 
   reflectNewRowsOrCols(
     nextDescriptors: Array<Partial<IRowColDescriptor>>,
-    dim: IGridDimension
+    dim: IGridDimension,
+    isCols: boolean
   ) {
     dim.rowColModel.clear(true);
-    const newRows = nextDescriptors.map((newRow) => {
-      const row = dim.rowColModel.create();
-      Object.assign(row, newRow);
-      return row;
+    const newDescriptors = nextDescriptors.map((newDescriptor) => {
+      const descriptor = dim.rowColModel.create();
+      Object.assign(descriptor, newDescriptor);
+      if (isCols) {
+        descriptor.builder = newDescriptor.builder || this.cellRendererBuilder;
+      }
+      return descriptor;
     });
-    dim.rowColModel.add(newRows);
-    return newRows;
+    dim.rowColModel.add(newDescriptors);
+    return newDescriptors;
   }
 
   descriptorsChanged(d1: Array<Partial<IRowColDescriptor>>, d2: Array<Partial<IRowColDescriptor>>) {
@@ -74,10 +82,10 @@ export class ReactGrid extends Component<IGridProps, IGridState> {
 
   shouldComponentUpdate(nextProps: IGridProps) {
     if (this.descriptorsChanged(this.props.rows, nextProps.rows)) {
-      this.reflectNewRowsOrCols(nextProps.rows, this.grid.rows);
+      this.reflectNewRowsOrCols(nextProps.rows, this.grid.rows, false);
     }
     if (this.descriptorsChanged(this.props.cols, nextProps.cols)) {
-      this.reflectNewRowsOrCols(nextProps.cols, this.grid.cols);
+      this.reflectNewRowsOrCols(nextProps.cols, this.grid.cols, true);
     }
 
     if (this.props.data !== nextProps.data) {
@@ -89,8 +97,19 @@ export class ReactGrid extends Component<IGridProps, IGridState> {
   componentDidMount() {
     this.ensureGridContainerInDOM();
     this.grid.build(this.gridContainer);
-    this.reflectNewRowsOrCols(this.props.rows, this.grid.rows);
-    this.reflectNewRowsOrCols(this.props.cols, this.grid.cols);
+    this.cellRendererBuilder = this.grid.colModel.createBuilder(
+      () => document.createElement('div'),
+      (element, { data, virtualCol, virtualRow }) => {
+        const rendered = this.props.cellRenderer && this.props.cellRenderer(virtualRow, virtualCol, data);
+        if (!element || !rendered || typeof rendered === 'string') {
+          return undefined;
+        }
+        ReactDOM.render(rendered, element);
+        return element;
+      }
+    );
+    this.reflectNewRowsOrCols(this.props.rows, this.grid.rows, false);
+    this.reflectNewRowsOrCols(this.props.cols, this.grid.cols, true);
     this.handleNewData(this.props.data);
   }
 

--- a/src/lib/components/grid.tsx
+++ b/src/lib/components/grid.tsx
@@ -4,6 +4,7 @@ import { Component, ReactElement } from 'react';
 import * as ReactDOM from 'react-dom';
 
 import {
+  ColModel,
   create,
   Grid,
   IColDescriptor,
@@ -50,14 +51,13 @@ export class ReactGrid extends Component<IGridProps, IGridState> {
 
   reflectNewRowsOrCols(
     nextDescriptors: Array<Partial<IRowColDescriptor>>,
-    dim: IGridDimension,
-    isCols: boolean
+    dim: IGridDimension
   ) {
     dim.rowColModel.clear(true);
     const newDescriptors = nextDescriptors.map((newDescriptor) => {
       const descriptor = dim.rowColModel.create();
       Object.assign(descriptor, newDescriptor);
-      if (isCols) {
+      if (dim.rowColModel instanceof ColModel) {
         descriptor.builder = newDescriptor.builder || this.cellRendererBuilder;
       }
       return descriptor;
@@ -82,10 +82,10 @@ export class ReactGrid extends Component<IGridProps, IGridState> {
 
   shouldComponentUpdate(nextProps: IGridProps) {
     if (this.descriptorsChanged(this.props.rows, nextProps.rows)) {
-      this.reflectNewRowsOrCols(nextProps.rows, this.grid.rows, false);
+      this.reflectNewRowsOrCols(nextProps.rows, this.grid.rows);
     }
     if (this.descriptorsChanged(this.props.cols, nextProps.cols)) {
-      this.reflectNewRowsOrCols(nextProps.cols, this.grid.cols, true);
+      this.reflectNewRowsOrCols(nextProps.cols, this.grid.cols);
     }
 
     if (this.props.data !== nextProps.data) {
@@ -108,8 +108,8 @@ export class ReactGrid extends Component<IGridProps, IGridState> {
         return element;
       }
     );
-    this.reflectNewRowsOrCols(this.props.rows, this.grid.rows, false);
-    this.reflectNewRowsOrCols(this.props.cols, this.grid.cols, true);
+    this.reflectNewRowsOrCols(this.props.rows, this.grid.rows);
+    this.reflectNewRowsOrCols(this.props.cols, this.grid.cols);
     this.handleNewData(this.props.data);
   }
 

--- a/src/lib/components/grid.tsx
+++ b/src/lib/components/grid.tsx
@@ -57,7 +57,7 @@ export class ReactGrid extends Component<IGridProps, IGridState> {
     const newDescriptors = nextDescriptors.map((newDescriptor) => {
       const descriptor = dim.rowColModel.create();
       Object.assign(descriptor, newDescriptor);
-      if (dim.rowColModel instanceof ColModel) {
+      if ((dim.rowColModel as ColModel).col !== undefined) {
         descriptor.builder = newDescriptor.builder || this.cellRendererBuilder;
       }
       return descriptor;

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -72,7 +72,7 @@ export default (opts) => {
     ] || []),
 
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify(isDev ? 'development' : 'production'), // Tells React to build in either dev or prod modes. https://facebook.github.io/react/downloads.html (See bottom)
+      'process.env.NODE_ENV': JSON.stringify(isDev ? 'production' : 'production'), // Tells React to build in either dev or prod modes. https://facebook.github.io/react/downloads.html (See bottom)
       __MOCK_DATA__: !!(isDemo || isMockData),
       __DEMO__: !!isDemo,
       __DEV__: !!isDev,


### PR DESCRIPTION
@alexkrolick alright this functions.. 

it does create some perf issues if you use too many however. reactdom.render is consistently taking almost 1ms per call.. as short as that sounds, that adds up when you are calling it N times per scroll where N is the number of cells with rendered content (in the current view). We only get to use 32ms of computation per draw if we want to maintain 30fps. so that 1ms is an eternity in render land. we may need to do a little more research to somehow make the reactdom render faster. this will work if you don't use it liberally however... 