### PR TITLE
feat(renderer): header renderer as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ class Table extends React.Component {
 - `rows` row options, see Row format
 - `cols` column options, see Col format
 - `ref` access the component and wrapped `grid`
-- `cellRenderer`: `(rowIndex: number, colIndex: number, data: IGridDataResult) => ReactElement<any> | string | undefined` render prop called for each visible cell
-- `headerCellRenderer` : `(virtualRow: number, virtualCol: number, data: IGridDataResult<any>) => ReactElement<any> | string | undefined` render prop called for each visible header cell
+- `cellRenderer`: `(context : {virtualRow: number, virtualCol: number, data: IGridDataResult<any>}) => ReactElement<any> | string | undefined` render prop called for each visible cell (where cell doesn't include headers)
+- `headerCellRenderer` : `(context : {virtualRow: number, virtualCol: number, data: IGridDataResult<any>}) => ReactElement<any> | string | undefined` render prop called for each visible header cell
 
 
 Props derived form the core grid options object:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ class Table extends React.Component {
 - `cols` column options, see Col format
 - `ref` access the component and wrapped `grid`
 - `cellRenderer`: `(rowIndex: number, colIndex: number, data: IGridDataResult) => ReactElement<any> | string | undefined` render prop called for each visible cell
+- `headerCellRenderer` : `(virtualRow: number, virtualCol: number, data: IGridDataResult<any>) => ReactElement<any> | string | undefined` render prop called for each visible header cell
 
 
 Props derived form the core grid options object:

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -23,7 +23,11 @@ const renderer = (row: number, col: number, data: { formatted: string }) => {
   return data.formatted;
 };
 
+const headerRenderer = (_row: number, col: number, data: { formatted: string }) => {
+  return col % 2 ? <b><i>{data.formatted}</i></b> : undefined;
+};
+
 render(
-  <ReactGrid rows={rows} cols={cols} cellRenderer={renderer} />,
+  <ReactGrid rows={rows} cols={cols} cellRenderer={renderer} headerCellRenderer={headerRenderer} />,
   document.getElementById('app')
 );

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,3 +1,4 @@
+import { IBuilderUpdateContext } from 'grid';
 import * as React from 'react';
 import { render } from 'react-dom';
 
@@ -13,7 +14,7 @@ const cols = _range(0, 100).map((_idx) => ({} as any));
 rows[0].header = true;
 rows[0].height = 50;
 
-const renderer = (row: number, col: number, data: { formatted: string }) => {
+const renderer = ({ virtualCol: col, virtualRow: row, data }: IBuilderUpdateContext) => {
   if (col % 2) {
     return <b>{data.formatted}</b>;
   }
@@ -23,7 +24,7 @@ const renderer = (row: number, col: number, data: { formatted: string }) => {
   return data.formatted;
 };
 
-const headerRenderer = (_row: number, col: number, data: { formatted: string }) => {
+const headerRenderer = ({ virtualCol: col, data }: IBuilderUpdateContext) => {
   return col % 2 ? <b><i>{data.formatted}</i></b> : undefined;
 };
 

--- a/src/lib/components/__tests__/grid.test.tsx
+++ b/src/lib/components/__tests__/grid.test.tsx
@@ -225,8 +225,9 @@ it('should use a colBuilder to supply React rendered content to the grid via cel
   const cellRendererBuilder = gridCols[0].builder;
   const rendered = cellRendererBuilder.render();
   expect(rendered).toBeDefined();
-  expect(cellRendererBuilder.update(rendered, { virtualRow: 1, virtualCol: 2, data: { formatted: 'poo' } })).toBe(rendered);
-  expect(cellRenderer).toHaveBeenCalledWith(1, 2, { formatted: 'poo' });
+  const ctx = { virtualRow: 1, virtualCol: 2, data: { formatted: 'poo' } };
+  expect(cellRendererBuilder.update(rendered, ctx)).toBe(rendered);
+  expect(cellRenderer).toHaveBeenCalledWith(ctx);
   expect(mockReactDomRender).toHaveBeenCalledWith(a, rendered);
 });
 
@@ -242,8 +243,9 @@ it('should use a rowBuilder to supply React rendered content to the grid via hea
   const cellRendererBuilder = gridRows[0].builder;
   const rendered = cellRendererBuilder.render();
   expect(rendered).toBeDefined();
-  expect(cellRendererBuilder.update(rendered, { virtualRow: 0, virtualCol: 1, data: { formatted: 'poo' } })).toBe(rendered);
-  expect(cellRenderer).toHaveBeenCalledWith(0, 1, { formatted: 'poo' });
+  const context = { virtualRow: 0, virtualCol: 1, data: { formatted: 'poo' } };
+  expect(cellRendererBuilder.update(rendered, context)).toBe(rendered);
+  expect(cellRenderer).toHaveBeenCalledWith(context);
   expect(mockReactDomRender).toHaveBeenCalledWith(a, rendered);
 });
 

--- a/src/lib/components/__tests__/grid.test.tsx
+++ b/src/lib/components/__tests__/grid.test.tsx
@@ -29,10 +29,11 @@ const mockDim = () => ({
   rowColModel: {
     clear: jest.fn(),
     add: jest.fn(),
-    create: jest.fn(makeDescriptor)
+    create: jest.fn(makeDescriptor),
+    numHeaders: jest.fn()
   }
 });
-const mockRowDim = mockDim();
+const mockRowDim = _merge({}, mockDim(), { rowColModel: { row: jest.fn() } });
 const mockColDim = _merge({}, mockDim(), { rowColModel: { col: jest.fn() } });
 const mockDataSetDirty = jest.fn();
 const mockGridBuild = jest.fn((o: any) => ({}));
@@ -41,6 +42,11 @@ const mockGridCreate = jest.fn((o: any) => ({
   rows: mockRowDim,
   cols: mockColDim,
   colModel: {
+    createBuilder: (render: any, update: any): any => ({
+      render, update
+    })
+  },
+  rowModel: {
     createBuilder: (render: any, update: any): any => ({
       render, update
     })
@@ -68,6 +74,7 @@ beforeEach(() => {
   mockDataSetDirty.mockClear();
   mockDataGet.mockClear();
   mockDataSet.mockClear();
+  mockReactDomRender.mockClear();
 });
 
 it('should render', () => {
@@ -221,4 +228,40 @@ it('should use a colBuilder to supply React rendered content to the grid via cel
   expect(cellRendererBuilder.update(rendered, { virtualRow: 1, virtualCol: 2, data: { formatted: 'poo' } })).toBe(rendered);
   expect(cellRenderer).toHaveBeenCalledWith(1, 2, { formatted: 'poo' });
   expect(mockReactDomRender).toHaveBeenCalledWith(a, rendered);
+});
+
+it('should use a rowBuilder to supply React rendered content to the grid via headerCellRenderer prop', () => {
+  const rows = [{ header: true }, { height: 4 }];
+  const cols = [{ fixed: true }, { width: 4 }];
+  const a = <a />;
+  const cellRenderer = jest.fn().mockReturnValue(a);
+  const reactGrid = mount(
+    <ReactGrid rows={rows} cols={cols} headerCellRenderer={cellRenderer} />
+  );
+  const gridRows = mockRowDim.rowColModel.add.mock.calls[0][0];
+  const cellRendererBuilder = gridRows[0].builder;
+  const rendered = cellRendererBuilder.render();
+  expect(rendered).toBeDefined();
+  expect(cellRendererBuilder.update(rendered, { virtualRow: 0, virtualCol: 1, data: { formatted: 'poo' } })).toBe(rendered);
+  expect(cellRenderer).toHaveBeenCalledWith(0, 1, { formatted: 'poo' });
+  expect(mockReactDomRender).toHaveBeenCalledWith(a, rendered);
+});
+
+it('should not call headerCellRenderer prop if its not a header', () => {
+  const rows = [{ header: true }, { height: 4 }];
+  const cols = [{ fixed: true }, { width: 4 }];
+  const a = <a />;
+  const cellRenderer = jest.fn().mockReturnValue(a);
+  mockRowDim.rowColModel.numHeaders.mockReturnValue(1);
+  const reactGrid = mount(
+    <ReactGrid rows={rows} cols={cols} headerCellRenderer={cellRenderer} />
+  );
+  const gridRows = mockRowDim.rowColModel.add.mock.calls[0][0];
+  const cellRendererBuilder = gridRows[0].builder;
+  const rendered = cellRendererBuilder.render();
+  expect(rendered).toBeDefined();
+
+  expect(cellRendererBuilder.update(rendered, { virtualRow: 1, virtualCol: 1, data: { formatted: 'poo' } })).toBe(undefined);
+  expect(cellRenderer).not.toHaveBeenCalled();
+  expect(mockReactDomRender).not.toHaveBeenCalled();
 });

--- a/src/lib/components/grid.tsx
+++ b/src/lib/components/grid.tsx
@@ -7,6 +7,7 @@ import {
   ColModel,
   create,
   Grid,
+  IBuilderUpdateContext,
   IColDescriptor,
   IGridDataResult,
   IGridDimension,
@@ -21,8 +22,8 @@ export interface IGridProps extends IGridOpts {
   rows: Array<Partial<IRowDescriptor>>;
   cols: Array<Partial<IColDescriptor>>;
   data?: Array<Array<IGridDataResult<any>>>;
-  cellRenderer?(virtualRow: number, virtualCol: number, data: IGridDataResult<any>): ReactElement<any> | string | undefined;
-  headerCellRenderer?(virtualRow: number, virtualCol: number, data: IGridDataResult<any>): ReactElement<any> | string | undefined;
+  cellRenderer?(context: IBuilderUpdateContext): ReactElement<any> | string | undefined;
+  headerCellRenderer?(context: IBuilderUpdateContext): ReactElement<any> | string | undefined;
 }
 
 export interface IGridState { }
@@ -106,8 +107,8 @@ export class ReactGrid extends Component<IGridProps, IGridState> {
     this.grid.build(this.gridContainer);
     this.cellRendererBuilder = this.grid.colModel.createBuilder(
       () => document.createElement('div'),
-      (element, { data, virtualCol, virtualRow }) => {
-        const rendered = this.props.cellRenderer && this.props.cellRenderer(virtualRow, virtualCol, data);
+      (element, context) => {
+        const rendered = this.props.cellRenderer && this.props.cellRenderer(context);
         if (!element || !rendered || typeof rendered === 'string') {
           return undefined;
         }
@@ -118,11 +119,12 @@ export class ReactGrid extends Component<IGridProps, IGridState> {
 
     this.headerCellRendererBuilder = this.grid.rowModel.createBuilder(
       () => document.createElement('div'),
-      (element, { data, virtualCol, virtualRow }) => {
+      (element, context) => {
+        const { virtualRow } = context;
         if (virtualRow >= this.grid.rows.rowColModel.numHeaders()) {
           return undefined;
         }
-        const rendered = this.props.headerCellRenderer && this.props.headerCellRenderer(virtualRow, virtualCol, data);
+        const rendered = this.props.headerCellRenderer && this.props.headerCellRenderer(context);
         if (!element || !rendered || typeof rendered === 'string') {
           return undefined;
         }

--- a/src/lib/components/grid.tsx
+++ b/src/lib/components/grid.tsx
@@ -13,7 +13,8 @@ import {
   IGridOpts,
   IRowColBuilder,
   IRowColDescriptor,
-  IRowDescriptor
+  IRowDescriptor,
+  RowModel
 } from 'grid';
 
 export interface IGridProps extends IGridOpts {
@@ -21,6 +22,7 @@ export interface IGridProps extends IGridOpts {
   cols: Array<Partial<IColDescriptor>>;
   data?: Array<Array<IGridDataResult<any>>>;
   cellRenderer?(virtualRow: number, virtualCol: number, data: IGridDataResult<any>): ReactElement<any> | string | undefined;
+  headerCellRenderer?(virtualRow: number, virtualCol: number, data: IGridDataResult<any>): ReactElement<any> | string | undefined;
 }
 
 export interface IGridState { }
@@ -28,6 +30,7 @@ export interface IGridState { }
 export class ReactGrid extends Component<IGridProps, IGridState> {
   grid: Grid;
   cellRendererBuilder: IRowColBuilder | undefined;
+  headerCellRendererBuilder: IRowColBuilder | undefined;
   gridContainer: HTMLElement;
   reactContainer: HTMLElement | null;
 
@@ -59,6 +62,10 @@ export class ReactGrid extends Component<IGridProps, IGridState> {
       Object.assign(descriptor, newDescriptor);
       if ((dim.rowColModel as ColModel).col !== undefined) {
         descriptor.builder = newDescriptor.builder || this.cellRendererBuilder;
+      }
+
+      if ((dim.rowColModel as RowModel).row !== undefined) {
+        descriptor.builder = newDescriptor.builder || this.headerCellRendererBuilder;
       }
       return descriptor;
     });
@@ -101,6 +108,21 @@ export class ReactGrid extends Component<IGridProps, IGridState> {
       () => document.createElement('div'),
       (element, { data, virtualCol, virtualRow }) => {
         const rendered = this.props.cellRenderer && this.props.cellRenderer(virtualRow, virtualCol, data);
+        if (!element || !rendered || typeof rendered === 'string') {
+          return undefined;
+        }
+        ReactDOM.render(rendered, element);
+        return element;
+      }
+    );
+
+    this.headerCellRendererBuilder = this.grid.rowModel.createBuilder(
+      () => document.createElement('div'),
+      (element, { data, virtualCol, virtualRow }) => {
+        if (virtualRow >= this.grid.rows.rowColModel.numHeaders()) {
+          return undefined;
+        }
+        const rendered = this.props.headerCellRenderer && this.props.headerCellRenderer(virtualRow, virtualCol, data);
         if (!element || !rendered || typeof rendered === 'string') {
           return undefined;
         }


### PR DESCRIPTION
@alexkrolick ok this works. i only opened the pr to discuss the function signature. i would love the convenience of only having col and data, but unfortunately it is possible to have multiple header rows so we need the row to be passed for that case. i left it the normal `row, col, data` here but i thought I'd bring it up for discussion to see if you thought having row as the last property (since it's a less likely use case) is more convenient or just weird.